### PR TITLE
Support Intel platform builds

### DIFF
--- a/build/520N/bin/.gitignore
+++ b/build/520N/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build/520N/blaze/acc/.gitattributes
+++ b/build/520N/blaze/acc/.gitattributes
@@ -1,0 +1,1 @@
+libPairHMMTask.so filter=lfs diff=lfs merge=lfs -text

--- a/build/520N/blaze/acc/libPairHMMTask.so
+++ b/build/520N/blaze/acc/libPairHMMTask.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0fe3655db48fada462967bb0dfdb4f424c7604c22ea78cfcf849795e5cb2fcd
+size 326608

--- a/build/520N/blaze/conf
+++ b/build/520N/blaze/conf
@@ -1,0 +1,26 @@
+verbose : 0
+profile : true
+
+platform {
+  id: "cpu"
+}
+
+platform {
+  id: "altr_opencl"
+  path : "/usr/local/falcon/blaze/platforms/libaltr_opencl.so"
+  cache_loc: "cpu"
+  acc {
+    id: "PairHMM"
+    path: "/usr/local/falcon/blaze/acc/libPairHMMTask.so"
+    param { key: "num_command_queues" value: "2" }
+    param {
+      key: "program_path"
+      value : "/usr/local/falcon/fpga/pmm.aocx"
+    }
+    param { key: "kernel_name" value: "pmm_intel" }
+    param { key: "num_kernels" value: "1" }
+    param { key: "num_sub_kernels" value: "2" }
+    param { key: "sub_kernel_name[0]" value: "pairhmm_driver" }
+    param { key: "sub_kernel_name[1]" value: "pairhmm_output" }
+  }
+}

--- a/build/520N/fcs-genome.conf
+++ b/build/520N/fcs-genome.conf
@@ -1,0 +1,3 @@
+gatk_path = /usr/local/falcon/tools/package/GATK3.jar
+gatk4_path = /usr/local/falcon/tools/package/GATK4.jar
+temp_dir = /local/temp

--- a/build/520N/fpga/.gitattributes
+++ b/build/520N/fpga/.gitattributes
@@ -1,0 +1,1 @@
+pmm.aocx filter=lfs diff=lfs merge=lfs -text

--- a/build/520N/fpga/pmm.aocx
+++ b/build/520N/fpga/pmm.aocx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd698d92f6afecc05537f453f5504790aad1317e8ef83fe98c3b90dfeaf221b7
+size 278122636

--- a/build/520N/tools/.gitignore
+++ b/build/520N/tools/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build/aws/blaze/acc/.gitattributes
+++ b/build/aws/blaze/acc/.gitattributes
@@ -1,0 +1,1 @@
+libPairHMMTask.so filter=lfs diff=lfs merge=lfs -text

--- a/build/aws/blaze/acc/libPairHMMTask.so
+++ b/build/aws/blaze/acc/libPairHMMTask.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db1e1a1edded383750651ce753ab7ef43349497284ec318529bf457bbc78f80
+size 392136

--- a/build/hwc/blaze/acc/.gitattributes
+++ b/build/hwc/blaze/acc/.gitattributes
@@ -1,0 +1,1 @@
+libPairHMMTask.so filter=lfs diff=lfs merge=lfs -text

--- a/build/hwc/blaze/acc/libPairHMMTask.so
+++ b/build/hwc/blaze/acc/libPairHMMTask.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db1e1a1edded383750651ce753ab7ef43349497284ec318529bf457bbc78f80
+size 392136

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 version=$(date +"%y%m%d")
+
+if [ "$#" -gt 0 ]; then
+  version="$1"
+fi
+
 base_dir=/curr/software/falcon-genome
 inst_dir=${base_dir}/$version
 module_dir=/curr/software/util/modulefiles/genome/

--- a/build/intel-pac/bin/.gitignore
+++ b/build/intel-pac/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build/intel-pac/blaze/acc/.gitattributes
+++ b/build/intel-pac/blaze/acc/.gitattributes
@@ -1,0 +1,1 @@
+libPairHMMTask.so filter=lfs diff=lfs merge=lfs -text

--- a/build/intel-pac/blaze/acc/libPairHMMTask.so
+++ b/build/intel-pac/blaze/acc/libPairHMMTask.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:381000f5aab9228d6537a6af4ede6bc0f8846a65b5c4dd82d3305dcc9211b0ce
+size 326720

--- a/build/intel-pac/blaze/conf
+++ b/build/intel-pac/blaze/conf
@@ -1,0 +1,26 @@
+verbose : 0
+profile : true
+
+platform {
+  id: "cpu"
+}
+
+platform {
+  id: "altr_opencl"
+  path : "/usr/local/falcon/blaze/platforms/libaltr_opencl.so"
+  cache_loc: "cpu"
+  acc {
+    id: "PairHMM"
+    path: "/usr/local/falcon/blaze/acc/libPairHMMTask.so"
+    param { key: "num_command_queues" value: "2" }
+    param {
+      key: "program_path"
+      value : "/usr/local/falcon/fpga/pmm.aocx"
+    }
+    param { key: "kernel_name" value: "pmm_intel" }
+    param { key: "num_kernels" value: "1" }
+    param { key: "num_sub_kernels" value: "2" }
+    param { key: "sub_kernel_name[0]" value: "pairhmm_driver" }
+    param { key: "sub_kernel_name[1]" value: "pairhmm_output" }
+  }
+}

--- a/build/intel-pac/fcs-genome.conf
+++ b/build/intel-pac/fcs-genome.conf
@@ -1,0 +1,3 @@
+gatk_path = /usr/local/falcon/tools/package/GATK3.jar
+gatk4_path = /usr/local/falcon/tools/package/GATK4.jar
+temp_dir = /local/temp

--- a/build/intel-pac/fpga/.gitattributes
+++ b/build/intel-pac/fpga/.gitattributes
@@ -1,0 +1,1 @@
+pmm.aocx filter=lfs diff=lfs merge=lfs -text

--- a/build/intel-pac/fpga/pmm.aocx
+++ b/build/intel-pac/fpga/pmm.aocx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b957557cbc8f7f9a3a8432c950410d056ced578e0e8a8f10cf63a628ab2243b
+size 30081756

--- a/build/intel-pac/tools/.gitignore
+++ b/build/intel-pac/tools/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/build/local/blaze/acc/.gitattributes
+++ b/build/local/blaze/acc/.gitattributes
@@ -1,0 +1,1 @@
+libPairHMMTask.so filter=lfs diff=lfs merge=lfs -text

--- a/build/local/blaze/acc/libPairHMMTask.so
+++ b/build/local/blaze/acc/libPairHMMTask.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1db1e1a1edded383750651ce753ab7ef43349497284ec318529bf457bbc78f80
+size 392136

--- a/build/local/blaze/conf
+++ b/build/local/blaze/conf
@@ -9,7 +9,7 @@ platform {
   cache_loc: "cpu"
   acc {
     id: "PairHMM"
-    path: "/usr/local/falcon/blaze/examples/libPairHMMTask.so"
+    path: "/usr/local/falcon/blaze/acc/libPairHMMTask.so"
     param {
       key: "program_path"
       value : "/usr/local/falcon/fpga/pmm.xclbin"


### PR DESCRIPTION
Remove ACC task compilation from blaze build, separate to build folder blaze/acc;
Add support for two Intel devices: Nallatech 520N and Intel PAC.