### PR TITLE
fix(GEN-840): bwa-flow seg fault for hg38 on merlin3

### DIFF
--- a/build/local/fpga/sw.xclbin
+++ b/build/local/fpga/sw.xclbin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4aeaea5f3a7736dd496eab8a5cd7e8b708611b6fc018c6e94b59667deb5112db
-size 68156362
+oid sha256:d35b0a1b04da1f769afe42663bac4990a1db606d1a596c3836335dd0f5d93d4a
+size 72037834


### PR DESCRIPTION
Fix the problem by updating the bitstream sw.xclbin to the correct version. Apparently, there was a version mismatch in the previous version.

AWS and Huawei build should not be affected.  

On merlin3, it passes all regression tests:
Hg38 feature test passed
Processing NA12878
Processing NA12891
Processing NA12892
Hg38 Germline test passed
Processing TCRBOA1

Note for {NA12878, NA12891, NA12892}, only 1_align.bats were run, to work around remaining issues on the test scripts. Nevertheless, only the alignment step is affected by the FPGA problem.
```
55 for id in ${array[@]}
156   do
157     echo "Processing $id"
158     export id=$id
159     $BATS $REG_DIR/regression_test/1_align.bats  >> regression.log
160     if [ $? -ne 0 ]; then
161       exit 1
162     fi
163   done

```