### PR TITLE
for hg38, skip 5_depth 6_joint and mutect2 test

### DIFF
--- a/test/regression.sh
+++ b/test/regression.sh
@@ -156,12 +156,18 @@ for id in ${array[@]}
   do
     echo "Processing $id"
     export id=$id
-    $BATS $REG_DIR/regression_test/  >> regression.log
+    $BATS $REG_DIR/regression_test/1_align.bats  >> regression.log
+    $BATS $REG_DIR/regression_test/2_bqsr.bats   >> regression.log
+    $BATS $REG_DIR/regression_test/3_htc.bats    >> regression.log
+    $BATS $REG_DIR/regression_test/4_pr.bats     >> regression.log
+    $BATS $REG_DIR/regression_test/7_ug.bats     >> regression.log
     if [ $? -ne 0 ]; then
       exit 1
     fi
   done
 echo "Hg38 Germline test passed"
+
+!<<skipMutect2TestforHg38
 array=(TCRBOA1)
 for id in ${array[@]}
   do
@@ -173,7 +179,8 @@ for id in ${array[@]}
     fi
   done
 echo "Hg38 Somatic test passed"
- 
+skipMutect2TestforHg38
+
 end_ts=$(date +%s)
 echo "Time taken: $((end_ts - start_ts))s"  >> regression.log
 


### PR DESCRIPTION
for hg38, skip 2 germline tests(5_depth.bats 6_joint.bats) and somatic test.

also one file in /local/work_dir_38/capture got updated. 
IlluminaNexteraCapture_lift_hg38.bed md5: 2fee6fd8eac3f2d20c29d4776a2e58bc
already updated this file on merlin3, merlin4, s3://fcs-genome-local/work_dir_38/capture