### PR TITLE
GEN-856, GEN-887: submodule support and cloud-helper timeout fix

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -184,6 +184,9 @@ function git_clone {
   export GIT_LFS_SKIP_SMUDGE=1;
 
   check_run git clone -b "$(git_get_branch "$rp")" --single-branch $git;
+  check_run cd $dir;
+  check_run git submodule update --init --recursive;
+  check_run cd -;
   echo $dir;
 }
 

--- a/test/lib/cloud-helper.sh
+++ b/test/lib/cloud-helper.sh
@@ -16,10 +16,10 @@ function set_env {
   fi;
 
   # decide which cloud are we running on
-  if [ "$(curl ${aws_metadata_url} -s -o /dev/null -w '%{http_code}')" = "200" ]; then
+  if [ "$(curl ${aws_metadata_url} -s -o /dev/null -m 2 -w '%{http_code}')" = "200" ]; then
     echo "Running on AWS";
     helper_cloud=aws;
-  elif [ "$(curl ${hwc_metadata_url} -s -o /dev/null -w '%{http_code}')" = "200" ]; then
+  elif [ "$(curl ${hwc_metadata_url} -s -o /dev/null -m 2 -w '%{http_code}')" = "200" ]; then
     echo "Running on Huawei";
     helper_cloud=hwc;
   else


### PR DESCRIPTION
This is a minor fix for two JIRA tickets:
1. http://jira.falcon-computing.com/browse/GEN-856
1. http://jira.falcon-computing.com/browse/GEN-887

No. 1 fixes the block issue on arbitrary appliances (when curl does not timeout by default). No 2 add support for submodules which is intended for improved build process such as: https://github.com/falcon-computing/gatk3/pull/50